### PR TITLE
Add factory for complex job build parameters

### DIFF
--- a/.travis.maven-settings.xml
+++ b/.travis.maven-settings.xml
@@ -50,6 +50,12 @@
           <id>repo.jenkins-ci.org</id>
           <url>http://repo.jenkins-ci.org/public/</url>
         </repository>
+        <!-- fix m.g.o-public repository -->
+        <repository>
+          <id>m.g.o-public</id>
+          <url>https://maven.java.net/content/groups/public/</url>
+          <layout>default</layout>
+        </repository>
 
       </repositories>
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The pipeline library comes with the following steps:
     * [`wrap.color`](vars/wrap.md#colormap-config-closure-body)
 
 ## Utilities
+* [Build Parameter Factory](src/io/wcm/devops/jenkins/pipeline/job/BuildParameterFactory.groovy)
 * [Integration Testing](vars/integrationTestUtils.md)
 * [Logging](docs/logging.md)
     * [`Logger`](src/io/wcm/devops/jenkins/pipeline/utils/logging/Logger.groovy)

--- a/jenkinsfiles/integration-tests.groovy
+++ b/jenkinsfiles/integration-tests.groovy
@@ -13,6 +13,7 @@ import io.wcm.devops.jenkins.pipeline.credentials.Credential
 import io.wcm.devops.jenkins.pipeline.credentials.CredentialConstants
 import io.wcm.devops.jenkins.pipeline.credentials.CredentialParser
 import io.wcm.devops.jenkins.pipeline.environment.EnvironmentConstants
+import io.wcm.devops.jenkins.pipeline.job.BuildParameterFactory
 import io.wcm.devops.jenkins.pipeline.managedfiles.ManagedFile
 import io.wcm.devops.jenkins.pipeline.managedfiles.ManagedFileConstants
 import io.wcm.devops.jenkins.pipeline.managedfiles.ManagedFileParser
@@ -130,6 +131,14 @@ node() {
       log.info(EnvironmentConstants.SCM_URL,  EnvironmentConstants.SCM_URL)
       log.info(EnvironmentConstants.TERM,  EnvironmentConstants.TERM)
       log.info(EnvironmentConstants.WORKSPACE,  EnvironmentConstants.WORKSPACE)
+    }
+  }
+
+  integrationTestUtils.integrationTestUtils.runTestsOnPackage("io.wcm.devops.jenkins.pipeline.job") {
+    integrationTestUtils.runTest("BuildParameterFactory") {
+      BuildParameterFactory buildParameterFactory = new BuildParameterFactory(this)
+      def checkboxParam = buildParameterFactory.createMultiCheckboxParameter("multiCheckboxParam","select multiple values",["val11","val12","val13"],["val11","val12","val13"])
+      def multiselectParam = buildParameterFactory.createMultiSelectParameter("multiSelectParam","select multiple values",["val21","val22","val23"],["val22"])
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -431,6 +431,7 @@
                   <excludes>
                     <exclude>com.google.guava:guava</exclude>
                     <exclude>commons-logging:commons-logging</exclude>
+                    <exclude>commons-codec:commons-codec</exclude>
                     <exclude>com.google.code.findbugs:jsr305</exclude>
                     <exclude>org.kohsuke:access-modifier-annotation</exclude>
                     <exclude>net.java.dev.jna:jna</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
       <artifactId>mailer</artifactId>
       <version>1.21</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>extended-choice-parameter</artifactId>
+      <version>0.76</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/io/wcm/devops/jenkins/pipeline/job/BuildParameterFactory.groovy
+++ b/src/io/wcm/devops/jenkins/pipeline/job/BuildParameterFactory.groovy
@@ -30,19 +30,30 @@ class BuildParameterFactory {
   public static final String PARAMETER_TYPE_MULTI_SELECT = "PT_MULTI_SELECT"
   public static final String PARAMETER_TYPE_CHECK_BOX = "PT_CHECKBOX"
   public static final String SELECTOR_DELIMITER = ","
-
   public static final Integer DEFAULT_VISIBLE_ITEM_COUNT = 5
 
   /**
-   * Creates a multi select parameter
-   *
-   * @param name The name of the parameter
-   * @param description The description of the parameter
-   * @param options The available options
-   * @param defaultValues The default selected values
-   * @param visibleItemCount Maximum visible items
-   * @return The created ExtendedChoiceParameterDefinition
+   * Reference to the CpsScript/WorkflowScript
    */
+  Script script
+
+  /**
+   *
+   * @param script Reference to the CpsScript/Workflow dcript
+   */
+  BuildParameterFactory(Script script) {
+    this.script = script
+  }
+/**
+ * Creates a multi select parameter
+ *
+ * @param name The name of the parameter
+ * @param description The description of the parameter
+ * @param options The available options
+ * @param defaultValues The default selected values
+ * @param visibleItemCount Maximum visible items
+ * @return The created ExtendedChoiceParameterDefinition
+ */
   ExtendedChoiceParameterDefinition createMultiSelectParameter(String name, String description, List<String> options, List<String> defaultValues = [], Integer visibleItemCount = BuildParameterFactory.DEFAULT_VISIBLE_ITEM_COUNT) {
     return createParameter(PARAMETER_TYPE_MULTI_SELECT, name, description, options, defaultValues, visibleItemCount)
   }
@@ -73,7 +84,7 @@ class BuildParameterFactory {
    *
    * @return The created ExtendedChoiceParameterDefinition
    */
-  private ExtendedChoiceParameterDefinition createParameter(String type, String name, String description, List<String> options, List<String> defaultValues = [], Integer visibleItemCount = BuildParameterFactory.DEFAULT_VISIBLE_ITEM_COUNT) {
+  private ExtendedChoiceParameterDefinition createParameter(String type, String name, String description, List<String> options, List<String> defaultValues, Integer visibleItemCount) {
     return new ExtendedChoiceParameterDefinition(
       name,
       type,

--- a/src/io/wcm/devops/jenkins/pipeline/job/BuildParameterFactory.groovy
+++ b/src/io/wcm/devops/jenkins/pipeline/job/BuildParameterFactory.groovy
@@ -1,0 +1,110 @@
+/*-
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2017 - 2019 wcm.io DevOps
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.devops.jenkins.pipeline.job
+
+import com.cwctravel.hudson.plugins.extended_choice_parameter.ExtendedChoiceParameterDefinition
+
+/**
+ * This eases the use of some parameter plugins like the Extended Choice Parameter plugin
+ * In order to use this factory you have to approve the script signature in the Jenkins script approval
+ */
+class BuildParameterFactory {
+
+  public static final String PARAMETER_TYPE_MULTI_SELECT = "PT_MULTI_SELECT"
+  public static final String PARAMETER_TYPE_CHECK_BOX = "PT_CHECKBOX"
+  public static final String SELECTOR_DELIMITER = ","
+
+  public static final Integer DEFAULT_VISIBLE_ITEM_COUNT = 5
+
+  /**
+   * Creates a multi select parameter
+   *
+   * @param name The name of the parameter
+   * @param description The description of the parameter
+   * @param options The available options
+   * @param defaultValues The default selected values
+   * @param visibleItemCount Maximum visible items
+   * @return The created ExtendedChoiceParameterDefinition
+   */
+  ExtendedChoiceParameterDefinition createMultiSelectParameter(String name, String description, List<String> options, List<String> defaultValues = [], Integer visibleItemCount = BuildParameterFactory.DEFAULT_VISIBLE_ITEM_COUNT) {
+    return createParameter(PARAMETER_TYPE_MULTI_SELECT, name, description, options, defaultValues, visibleItemCount)
+  }
+
+  /**
+   * Creates a multi checkbox parameter
+   *
+   * @param name The name of the parameter
+   * @param description The description of the parameter
+   * @param options The available options
+   * @param defaultValues The default selected values
+   * @param visibleItemCount Maximum visible items
+   * @return The created ExtendedChoiceParameterDefinition
+   */
+  ExtendedChoiceParameterDefinition createMultiCheckboxParameter(String name, String description, List<String> options, List<String> defaultValues = [], Integer visibleItemCount = BuildParameterFactory.DEFAULT_VISIBLE_ITEM_COUNT) {
+    return createParameter(PARAMETER_TYPE_CHECK_BOX, name, description, options, defaultValues, visibleItemCount)
+  }
+
+  /**
+   * Creates a ExtendedChoiceParameterDefinition with the given type
+   *
+   * @param type The type of the ExtendedChoiceParameterDefinition to create
+   * @param name The name of the parameter
+   * @param description The description of the parameter
+   * @param options The available options
+   * @param defaultValues The default selected values
+   * @param visibleItemCount Maximum visible items
+   *
+   * @return The created ExtendedChoiceParameterDefinition
+   */
+  private ExtendedChoiceParameterDefinition createParameter(String type, String name, String description, List<String> options, List<String> defaultValues = [], Integer visibleItemCount = BuildParameterFactory.DEFAULT_VISIBLE_ITEM_COUNT) {
+    return new ExtendedChoiceParameterDefinition(
+      name,
+      type,
+      options.join(SELECTOR_DELIMITER),
+      null, // project name
+      null, // propertyFile
+      null, // groovyScript
+      null, // groovyScriptFile
+      null, // bindings
+      null, // groovyClassPath
+      null, // propertykey
+      defaultValues.join(SELECTOR_DELIMITER), //default property value
+      null, //defaultPropertyFile
+      null, //defaultGroovyScript
+      null, //defaultGroovyScriptFile
+      null, //default bindings
+      null, //defaultGroovyClasspath
+      null, //defaultPropertyKey
+      null, //descriptionPropertyValue
+      null, //descriptionPropertyFile
+      null, //descriptionGroovyScript
+      null, //descriptionGroovyScriptFile
+      null, //descriptionBindings
+      null, //descriptionGroovyClasspath
+      null, //descriptionPropertyKey
+      null,// javascript file
+      null, // javascript
+      false, // save json param to file
+      false, // quote
+      visibleItemCount, // visible item count
+      description,
+      SELECTOR_DELIMITER)
+  }
+}

--- a/test/io/wcm/devops/jenkins/pipeline/job/BuildParameterFactoryTest.groovy
+++ b/test/io/wcm/devops/jenkins/pipeline/job/BuildParameterFactoryTest.groovy
@@ -1,0 +1,103 @@
+/*-
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2017 - 2019 wcm.io DevOps
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.devops.jenkins.pipeline.job
+
+import com.cwctravel.hudson.plugins.extended_choice_parameter.ExtendedChoiceParameterDefinition
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.assertEquals
+
+class BuildParameterFactoryTest {
+
+  BuildParameterFactory factory
+
+  ExtendedChoiceParameterDefinition underTest
+
+  @Before
+  void setUp() throws Exception {
+    factory = new BuildParameterFactory()
+  }
+
+  @Test
+  void shouldCreateDefaultMultiSelectParam() {
+    List expectedValueList = ["value1", "value2", "value3"]
+    List expectedDefaultValueList = []
+    String expectedValues = expectedValueList.join(BuildParameterFactory.SELECTOR_DELIMITER)
+    String expectedDefaultValues = expectedDefaultValueList.join(BuildParameterFactory.SELECTOR_DELIMITER)
+
+    underTest = factory.createMultiSelectParameter("multiSelectName", "multiSelectDescription", expectedValueList)
+    assertEquals("multiSelectName", underTest.getName())
+    assertEquals("multiSelectDescription", underTest.getDescription())
+    assertEquals(BuildParameterFactory.PARAMETER_TYPE_MULTI_SELECT, underTest.getType())
+    assertEquals(expectedValues, underTest.getValue())
+    assertEquals(expectedDefaultValues, underTest.getDefaultValue())
+    assertEquals(BuildParameterFactory.DEFAULT_VISIBLE_ITEM_COUNT, underTest.getVisibleItemCount())
+  }
+
+  @Test
+  void shouldCreateCustomMultiSelectParam() {
+    List expectedValueList = ["value1", "value2", "value3", "value4"]
+    List expectedDefaultValueList = ["value2", "value3"]
+    String expectedValues = expectedValueList.join(BuildParameterFactory.SELECTOR_DELIMITER)
+    String expectedDefaultValues = expectedDefaultValueList.join(BuildParameterFactory.SELECTOR_DELIMITER)
+
+    underTest = factory.createMultiSelectParameter("multiSelectName", "multiSelectDescription", expectedValueList, expectedDefaultValueList, 10)
+    assertEquals("multiSelectName", underTest.getName())
+    assertEquals("multiSelectDescription", underTest.getDescription())
+    assertEquals(BuildParameterFactory.PARAMETER_TYPE_MULTI_SELECT, underTest.getType())
+    assertEquals(expectedValues, underTest.getValue())
+    assertEquals(expectedDefaultValues, underTest.getDefaultValue())
+    assertEquals(10, underTest.getVisibleItemCount())
+  }
+
+  @Test
+  void shouldCreateDefaultMultiCheckboxParam() {
+    List expectedValueList = ["value1", "value2", "value3"]
+    List expectedDefaultValueList = []
+    String expectedValues = expectedValueList.join(BuildParameterFactory.SELECTOR_DELIMITER)
+    String expectedDefaultValues = expectedDefaultValueList.join(BuildParameterFactory.SELECTOR_DELIMITER)
+
+    underTest = factory.createMultiCheckboxParameter("multiCheckboxName", "multiCheckboxDescription", expectedValueList)
+    assertEquals("multiCheckboxName", underTest.getName())
+    assertEquals("multiCheckboxDescription", underTest.getDescription())
+    assertEquals(BuildParameterFactory.PARAMETER_TYPE_CHECK_BOX, underTest.getType())
+    assertEquals(expectedValues, underTest.getValue())
+    assertEquals(expectedDefaultValues, underTest.getDefaultValue())
+    assertEquals(BuildParameterFactory.DEFAULT_VISIBLE_ITEM_COUNT, underTest.getVisibleItemCount())
+  }
+
+  @Test
+  void shouldCreateCustomMultiCheckboxParam() {
+    List expectedValueList = ["value1", "value2", "value3", "value4"]
+    List expectedDefaultValueList = ["value2", "value3"]
+    String expectedValues = expectedValueList.join(BuildParameterFactory.SELECTOR_DELIMITER)
+    String expectedDefaultValues = expectedDefaultValueList.join(BuildParameterFactory.SELECTOR_DELIMITER)
+
+    underTest = factory.createMultiCheckboxParameter("multiCheckboxName", "multiCheckboxDescription", expectedValueList, expectedDefaultValueList, 10)
+    assertEquals("multiCheckboxName", underTest.getName())
+    assertEquals("multiCheckboxDescription", underTest.getDescription())
+    assertEquals(BuildParameterFactory.PARAMETER_TYPE_CHECK_BOX, underTest.getType())
+    assertEquals(expectedValues, underTest.getValue())
+    assertEquals(expectedDefaultValues, underTest.getDefaultValue())
+    assertEquals(10, underTest.getVisibleItemCount())
+  }
+
+}

--- a/test/io/wcm/devops/jenkins/pipeline/job/BuildParameterFactoryTest.groovy
+++ b/test/io/wcm/devops/jenkins/pipeline/job/BuildParameterFactoryTest.groovy
@@ -20,20 +20,21 @@
 package io.wcm.devops.jenkins.pipeline.job
 
 import com.cwctravel.hudson.plugins.extended_choice_parameter.ExtendedChoiceParameterDefinition
-import org.junit.Before
+import io.wcm.testing.jenkins.pipeline.CpsScriptTestBase
 import org.junit.Test
 
 import static org.junit.Assert.assertEquals
 
-class BuildParameterFactoryTest {
+class BuildParameterFactoryTest extends CpsScriptTestBase {
 
   BuildParameterFactory factory
 
   ExtendedChoiceParameterDefinition underTest
 
-  @Before
+  @Override
   void setUp() throws Exception {
-    factory = new BuildParameterFactory()
+    super.setUp()
+    factory = new BuildParameterFactory(this.script)
   }
 
   @Test


### PR DESCRIPTION
At the moment it not possible to create ExtendedChoiceParameterDefinition parameters in an easy, pipeline way.

This PR adds a factory to ease the creation of multi select or multi checkbox parameters.