### PR TITLE
Fix best match evaluation by taking pattern length into account during score calculation.

### DIFF
--- a/src/io/wcm/devops/jenkins/pipeline/utils/PatternMatcher.groovy
+++ b/src/io/wcm/devops/jenkins/pipeline/utils/PatternMatcher.groovy
@@ -54,17 +54,19 @@ class PatternMatcher implements Serializable {
     int matchScore = 0
     // Walk through list and match each pattern of the PatternMatchable against the searchvalue
     items.each {
-      item ->
-        log.debug("try to match file: " + item + " with pattern " + item.getPattern())
-        Matcher matcher = searchValue =~ item.getPattern()
+      patternMatchable ->
+        log.debug("try to match file: " + patternMatchable + " with pattern " + patternMatchable.getPattern())
+        Matcher matcher = searchValue =~ patternMatchable.getPattern()
         // check if there is a match
         if (matcher) {
           String group = matcher[0]
+          // match score is pattern length + matched group length
+          int currentMatchScore = group.length() + patternMatchable.pattern.length()
           // check if matcher has a group and if the matched length/score is better as the last found match
-          if (group && (group.length() > matchScore)) {
-            matchScore = group.length()
+          if (group && (currentMatchScore > matchScore)) {
+            matchScore = currentMatchScore
             log.trace("match found with score $matchScore")
-            result = item
+            result = patternMatchable
           }
         }
     }

--- a/test/io/wcm/devops/jenkins/pipeline/utils/PatternMatcherTest.groovy
+++ b/test/io/wcm/devops/jenkins/pipeline/utils/PatternMatcherTest.groovy
@@ -42,22 +42,36 @@ class PatternMatcherTest extends DSLTestBase {
   @Test
   void shouldFindMatch() {
     PatternMatchable result = underTest.getBestMatch("pattern1", this.createTestCredentials())
-    assertNotNull("The CredentialUtilTest should find one ManagedFile", result)
+    assertNotNull("The shouldFindMatch should find one Credential", result)
     assertEquals("pattern1-id", result.getId())
   }
 
   @Test
   void shouldFindFirstMatch() {
     PatternMatchable result = underTest.getBestMatch("pattern", this.createTestCredentials())
-    assertNotNull("The CredentialUtilTest should find one ManagedFile", result)
+    assertNotNull("The shouldFindFirstMatch should find one Credential", result)
     assertEquals("pattern-id", result.getId())
   }
 
   @Test
   void shouldFindBetterMatch() {
     PatternMatchable result = underTest.getBestMatch("pattern-better", this.createTestCredentials())
-    assertNotNull("The CredentialUtilTest should find one ManagedFile", result)
+    assertNotNull("The shouldFindBetterMatch should find one Credential", result)
     assertEquals("i-am-a-better-match-id", result.getId())
+  }
+
+  @Test
+  void shouldMatchCorrectTldDomainCredentials() {
+    PatternMatchable result = underTest.getBestMatch("www.domain.tld", this.createTestCredentials())
+    assertNotNull("The shouldMatchCorrectDomainCredentials should find one Credential", result)
+    assertEquals("domain-matched", result.getId())
+  }
+
+  @Test
+  void shouldMatchCorrectSubDomainCredentials() {
+    PatternMatchable result = underTest.getBestMatch("sub3.sub2.sub1.domain.tld", this.createTestCredentials())
+    assertNotNull("The shouldMatchCorrectDomainCredentials should find one Credential", result)
+    assertEquals("detailed-domain-matched", result.getId())
   }
 
   List<Credential> createTestCredentials() {
@@ -67,6 +81,9 @@ class PatternMatcherTest extends DSLTestBase {
     files.push(new Credential("pattern", "pattern-id", "pattern2-name"))
     files.push(new Credential("pattern", "i-should-not-be-returned-id", "i-should-not-be-returned-name"))
     files.push(new Credential("pattern-b", "i-am-a-better-match-id", "i-am-a-better-match-name"))
+    files.push(new Credential(/.*\.domain\.tld/, "domain-matched", "domain-matched-name"))
+    files.push(new Credential(/.*\.sub2\.sub1\.domain\.tld/, "detailed-domain-matched", "detailed-domain-matched-name"))
+
 
     return files
   }


### PR DESCRIPTION
Previously the score was calculated by using the machted group.length() only.
This can lead to wrong results with e.g.:

* `/.*\.domain\.tld/`
* `/.*\.sub2\.sub1\.domain\.tld/`

`where sub3.sub2.sub1.domain.tld` will match to `/.*\.domain\.tld/` instead of `/.*\.sub2\.sub1\.domain\.tld/`

