### PR TITLE
Retry Ansible Galaxy installs 3x by default

### DIFF
--- a/test/io/wcm/testing/jenkins/pipeline/LibraryIntegrationTestBase.groovy
+++ b/test/io/wcm/testing/jenkins/pipeline/LibraryIntegrationTestBase.groovy
@@ -20,47 +20,17 @@
 package io.wcm.testing.jenkins.pipeline
 
 import com.lesfurets.jenkins.unit.BasePipelineTest
-import hudson.AbortException
-import hudson.model.Run
-import io.wcm.devops.jenkins.pipeline.environment.EnvironmentConstants
+import io.wcm.devops.jenkins.pipeline.utils.logging.LogLevel
+import io.wcm.devops.jenkins.pipeline.utils.logging.Logger
 import io.wcm.testing.jenkins.pipeline.global.lib.SelfSourceRetriever
-import io.wcm.testing.jenkins.pipeline.plugins.AnsiColorPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.AnsiblePluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.BadgePluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.CheckstylePluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.ConfigFileProviderPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.EmailExtPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.FindBugsPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.HTTPRequestPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.JUnitPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.MQTTNotificationPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.MattermostNotificationPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.PMDPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.PipelineStageStepPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.PipelineUtilityStepsPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.SSHAgentPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.TaskScannerPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.TimestamperPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.VersionNumberPluginMock
-import io.wcm.testing.jenkins.pipeline.plugins.WorkflowDurableTaskStepPluginMock
+import io.wcm.testing.jenkins.pipeline.plugins.*
 import io.wcm.testing.jenkins.pipeline.plugins.credentials.CredentialsPluginMock
 import io.wcm.testing.jenkins.pipeline.recorder.StepRecorder
-import io.wcm.testing.jenkins.pipeline.recorder.StepRecorderAssert
-import org.apache.maven.model.Model
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader
-import org.apache.tools.ant.DirectoryScanner
-import org.jenkinsci.plugins.pipeline.utility.steps.fs.FileWrapper
 import org.junit.Before
-import org.jvnet.hudson.tools.versionnumber.VersionNumberBuildInfo
-import org.jvnet.hudson.tools.versionnumber.VersionNumberCommon
-import org.jvnet.hudson.tools.versionnumber.VersionNumberStep
 
-import java.nio.file.Path
 import java.util.regex.Pattern
 
 import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
-import static io.wcm.testing.jenkins.pipeline.StepConstants.*
-import static org.mockito.Mockito.mock
 
 /**
  * Base class for integration tests that use the JenkinsPipelineUnit testing framework
@@ -351,6 +321,8 @@ class LibraryIntegrationTestBase extends BasePipelineTest {
       // call helper function to enable tests to execute code before loading the script
       beforeLoadingScript()
       def script = loadScript(scriptPath)
+      Logger.initialized = false
+      Logger.init((groovy.lang.Script) script, LogLevel.INFO)
       // call helper function to enable tests to redirect pipeline steps into own callbacks
       afterLoadingScript()
       if (config != null) {

--- a/test/io/wcm/testing/jenkins/pipeline/StepConstants.groovy
+++ b/test/io/wcm/testing/jenkins/pipeline/StepConstants.groovy
@@ -95,6 +95,8 @@ class StepConstants {
   public final static String READ_MAVEN_POM = "readMavenPom"
   public final static String READ_YAML = "readYaml"
 
+  public final static String RETRY = "retry"
+
   public final static String REMOVE_BADGES = "removeBadges"
   public final static String REMOVE_HTML_BADGES = "removeHtmlBadges"
 

--- a/test/vars/ansible/AnsibleInstallRolesIT.groovy
+++ b/test/vars/ansible/AnsibleInstallRolesIT.groovy
@@ -23,9 +23,11 @@ package vars.ansible
 import io.wcm.testing.jenkins.pipeline.LibraryIntegrationTestBase
 import io.wcm.testing.jenkins.pipeline.StepConstants
 import io.wcm.testing.jenkins.pipeline.recorder.StepRecorderAssert
-import net.sf.json.JSONObject
+import org.hamcrest.CoreMatchers
 import org.junit.Assert
 import org.junit.Test
+
+import static org.junit.Assert.assertThat
 
 class AnsibleInstallRolesIT extends LibraryIntegrationTestBase {
 
@@ -40,6 +42,8 @@ class AnsibleInstallRolesIT extends LibraryIntegrationTestBase {
     loadAndExecuteScript("vars/ansible/jobs/ansibleInstallRolesDefaultTestJob.groovy")
     Map toolCall = StepRecorderAssert.assertOnce(StepConstants.TOOL)
     String shellCall = StepRecorderAssert.assertOnce(StepConstants.SH)
+    String logMessages = this.context.dslMock.getLogMessages().toString()
+    assertThat(logMessages, CoreMatchers.containsString("[INFO] installRoles : running ansible-galaxy (1/3)]"))
 
     Assert.assertEquals([
       name: "ansible-installation",

--- a/test/vars/ansible/jobs/ansibleInstallRolesDefaultTestJob.groovy
+++ b/test/vars/ansible/jobs/ansibleInstallRolesDefaultTestJob.groovy
@@ -25,9 +25,6 @@ import io.wcm.devops.jenkins.pipeline.utils.logging.Logger
 import static io.wcm.devops.jenkins.pipeline.utils.ConfigConstants.*
 
 def execute() {
-  Logger.initialized = false
-  Logger.init(this, LogLevel.INFO)
-
   ansible.installRoles(
     (ANSIBLE): [
       (ANSIBLE_INSTALLATION)      : "ansible-installation",

--- a/test/vars/ansible/jobs/ansibleInstallRolesDefaultTestJob.groovy
+++ b/test/vars/ansible/jobs/ansibleInstallRolesDefaultTestJob.groovy
@@ -19,9 +19,15 @@
  */
 package vars.ansible.jobs
 
+import io.wcm.devops.jenkins.pipeline.utils.logging.LogLevel
+import io.wcm.devops.jenkins.pipeline.utils.logging.Logger
+
 import static io.wcm.devops.jenkins.pipeline.utils.ConfigConstants.*
 
 def execute() {
+  Logger.initialized = false
+  Logger.init(this, LogLevel.INFO)
+
   ansible.installRoles(
     (ANSIBLE): [
       (ANSIBLE_INSTALLATION)      : "ansible-installation",

--- a/test/vars/libraryIntegrationTestBase/jobs/retryTestJob.groovy
+++ b/test/vars/libraryIntegrationTestBase/jobs/retryTestJob.groovy
@@ -1,0 +1,32 @@
+/*-
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2017 - 2020 wcm.io DevOps
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package vars.libraryIntegrationTestBase.jobs
+
+import io.wcm.devops.jenkins.pipeline.environment.EnvironmentConstants
+
+import static io.wcm.devops.jenkins.pipeline.utils.ConfigConstants.SCM
+
+def execute() {
+  retry(3) {
+    sh("some_randomly_failing_command")
+  }
+}
+
+return this

--- a/vars/ansible.groovy
+++ b/vars/ansible.groovy
@@ -219,6 +219,7 @@ void installRoles(Map config) {
 
     String requirementsPath = ansibleCfg[ANSIBLE_GALAXY_ROLE_FILE] ?: null
     Boolean requirementsForce = ansibleCfg[ANSIBLE_GALAXY_FORCE] != null ? ansibleCfg[ANSIBLE_GALAXY_FORCE] : false
+    Integer retryAttempt = 1
 
     this.withInstallation(config) {
         CommandBuilder commandBuilder = new CommandBuilderImpl(this.steps, "ansible-galaxy")
@@ -229,7 +230,9 @@ void installRoles(Map config) {
         }
         log.debug("command", commandBuilder.build())
         retry(3) {
+            log.info("running ansible-galaxy (${retryAttempt}/3)")
             sh(commandBuilder.build())
+            retryAttempt += 1
         }
     }
 

--- a/vars/ansible.groovy
+++ b/vars/ansible.groovy
@@ -228,7 +228,9 @@ void installRoles(Map config) {
             commandBuilder.addArgument("--force")
         }
         log.debug("command", commandBuilder.build())
-        sh(commandBuilder.build())
+        retry(3) {
+            sh(commandBuilder.build())
+        }
     }
 
 }


### PR DESCRIPTION
Since the Ansible Galaxy API tends to be unavailable from time to time, the retry ensures that you don't have to manually restart a Jenkins job using this step.