### PR TITLE
Return null value when the pipeline is unable to detect the parent branch

### DIFF
--- a/test/vars/gitTools/GitToolsIT.groovy
+++ b/test/vars/gitTools/GitToolsIT.groovy
@@ -94,8 +94,8 @@ class GitToolsIT extends LibraryIntegrationTestBase {
       ]
     ]
     String expectedParentBranch = "origin/develop"
-    String acutalParentBranch = loadAndExecuteScript("vars/gitTools/jobs/getParentBranchTestJob.groovy")
-    Assert.assertEquals(expectedParentBranch, acutalParentBranch)
+    String actualParentBranch = loadAndExecuteScript("vars/gitTools/jobs/getParentBranchTestJob.groovy")
+    Assert.assertEquals(expectedParentBranch, actualParentBranch)
   }
 
   @Test
@@ -104,11 +104,32 @@ class GitToolsIT extends LibraryIntegrationTestBase {
       [
         script: "git branch --list --remote | grep origin/develop",
         result: 1
+      ],
+      [
+        script: "git branch --list --remote | grep origin/master",
+        result: 0
       ]
     ]
     String expectedParentBranch = "origin/master"
-    String acutalParentBranch = loadAndExecuteScript("vars/gitTools/jobs/getParentBranchTestJob.groovy")
-    Assert.assertEquals(expectedParentBranch, acutalParentBranch)
+    String actualParentBranch = loadAndExecuteScript("vars/gitTools/jobs/getParentBranchTestJob.groovy")
+    Assert.assertEquals(expectedParentBranch, actualParentBranch)
+  }
+
+
+  @Test
+  void shouldFindNoParentBranch() {
+    mockedShellCommands = [
+      [
+        script: "git branch --list --remote | grep origin/develop",
+        result: 1
+      ],
+      [
+        script: "git branch --list --remote | grep origin/master",
+        result: 1
+      ]
+    ]
+    String actualParentBranch = loadAndExecuteScript("vars/gitTools/jobs/getParentBranchTestJob.groovy")
+    Assert.assertNull(actualParentBranch)
   }
 
   def shellMapCallback = { Map incomingCommand ->

--- a/vars/gitTools.groovy
+++ b/vars/gitTools.groovy
@@ -275,19 +275,29 @@ List<String> _lookupRepositoryCredentials(GitRepository repo, List credentialIds
  */
 String getParentBranch() {
   Logger log = new Logger("getParentBranch")
-  String parentBranch = "origin/develop"
+  Integer branchResultCode = -1
 
-  log.info("check if git repo has a remote branch named: '${parentBranch}'")
-  Integer developBranchResultCode = sh(script: "git branch --list --remote | grep ${parentBranch}", returnStatus: true)
-  log.debug("git command result code:", developBranchResultCode)
+  log.info("check if git repo has a remote branch named: 'origin/develop'")
+  branchResultCode = sh(script: "git branch --list --remote | grep origin/develop", returnStatus: true)
+  log.debug("git command result code for origin/develop:", branchResultCode)
 
-  if (developBranchResultCode != 0) {
-    log.info("No remote branch with the name '${parentBranch}' found, falling back to 'origin/master'")
-    parentBranch = "origin/master"
+  // origin/develop branch was found
+  if (branchResultCode == 0) {
+    return "origin/develop"
   }
 
-  log.info("evaluated parent branch: '${parentBranch}'")
-  return parentBranch
+  log.info("check if git repo has a remote branch named: 'origin/master'")
+  branchResultCode = sh(script: "git branch --list --remote | grep origin/master", returnStatus: true)
+  log.debug("git command result code for origin/master:", branchResultCode)
+
+  // origin/develop branch was found
+  if (branchResultCode == 0) {
+    return "origin/master"
+  }
+
+  log.info("unable to detect parent branch, returning", null)
+
+  return null
 }
 
 /**


### PR DESCRIPTION
We need to detect the case when the parent branch is not determinable like when running in Gitlab Branch Source branches.