### PR TITLE
Mqtt notification: don't do anything if disabled

### DIFF
--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -187,6 +187,7 @@ void mqtt(Map config = [:]) {
 
   if (!mqttEnabled) {
     log.info("mqtt notification is disabled.")
+    return
   }
 
   String broker = mqttConfig[NOTIFY_MQTT_BROKER]


### PR DESCRIPTION
Right now it's not possible to disable MQTT