### PR TITLE
Enable SonarCloud and Java 11

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1,30 +1,54 @@
-# Default build validation "clean verify" for non-experimental branches
+# Build validation
 
 name: Build
 
 on:
   push:
     branches-ignore:
-      - 'experimental/**'
+      - experimental/**
   pull_request:
+    types: [opened, synchronize, reopened]
     branches-ignore:
-      - 'experimental/**'
+      - experimental/**
+  workflow_dispatch:
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        java: [8, 11]
+        os: [ubuntu-latest]
+        distribution: [temurin]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
-          distribution: temurin
-          java-version: 8
+          distribution: ${{ matrix.distribution }}
+          java-version: ${{ matrix.java }}
           cache: 'maven'
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
 
       - name: Build and verify
         run: mvn -s ./.maven-settings.xml -B -U clean verify
+
+      - name: Analyze in SonarCloud
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        # SONAR_TOKEN is not present when building for external PR
+        run:  ([ -z $SONAR_TOKEN ] || mvn -s ./.maven-settings.xml -Pcontinuous-integration -B sonar:sonar -Dsonar.projectKey=${{github.repository_owner}}_${{github.event.repository.name}} -Dsonar.projectName=${{github.event.repository.name}})
+        if: ${{ matrix.java == '11' && matrix.os == 'ubuntu-latest' }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build](https://github.com/wcm-io-devops/jenkins-pipeline-library/workflows/Build/badge.svg)](https://github.com/wcm-io-devops/jenkins-pipeline-library/actions?query=workflow%3ABuild)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=wcm-io-devops_jenkins-pipeline-library&metric=coverage)](https://sonarcloud.io/summary/new_code?id=wcm-io-devops_jenkins-pipeline-library)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.wcm.devops.jenkins/io.wcm.devops.jenkins.pipeline-library/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.wcm.devops.jenkins/io.wcm.devops.jenkins.pipeline-library)
 [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/io.wcm.devops.jenkins/io.wcm.devops.jenkins.pipeline-library.svg)](https://oss.sonatype.org/content/repositories/snapshots/io/wcm/devops/jenkins/io.wcm.devops.jenkins.pipeline-library/)
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,10 @@
     <animal.sniffer.skip>true</animal.sniffer.skip>
     <java.level>8</java.level>
     <groovy.version>2.4.12</groovy.version>
+
+    <!-- SonarCloud -->
+    <sonar.organization>wcm-io-devops</sonar.organization>
+    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
   </properties>
 
   <inceptionYear>2017</inceptionYear>


### PR DESCRIPTION
we have switched for all wcm.io DevOps projects from codecov.io to SonarCloud

however, the sonar-maven-plugin requires Java 11, and the jenkins-pipeline-library currently does not build with Java 11