### PR TITLE
removed private access to field

### DIFF
--- a/src/io/wcm/devops/jenkins/pipeline/managedfiles/ManagedFile.groovy
+++ b/src/io/wcm/devops/jenkins/pipeline/managedfiles/ManagedFile.groovy
@@ -35,7 +35,6 @@ class ManagedFile extends PatternMatchable implements Serializable {
 
   ManagedFile(String pattern, String id, String name = null, String comment = null) {
     super(pattern, id)
-    this.id = id
     this.name = name
     this.comment = comment
   }


### PR DESCRIPTION
Removed redundant field assignment leading to an error in pipelines. I ran it through the same pipelines and it fixed the issue

Before Fix:
![image](https://user-images.githubusercontent.com/8678523/229108523-7da9abe9-82e0-4a7e-a74a-fa0260a53346.png)

```
java.lang.IllegalAccessError: class io.wcm.devops.jenkins.pipeline.managedfiles.ManagedFile tried to access private field io.wcm.devops.jenkins.pipeline.model.PatternMatchable.id (io.wcm.devops.jenkins.pipeline.managedfiles.ManagedFile and io.wcm.devops.jenkins.pipeline.model.PatternMatchable are in unnamed module of loader org.jenkinsci.plugins.workflow.cps.CpsGroovyShell$CleanGroovyClassLoader @f16bbba)
	at io.wcm.devops.jenkins.pipeline.managedfiles.ManagedFile.<init>(ManagedFile.groovy:38)
	at io.wcm.devops.jenkins.pipeline.managedfiles.ManagedFile.<init>(ManagedFile.groovy:37)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
```


After Fix:
![image](https://user-images.githubusercontent.com/8678523/229108592-2a5488c2-1982-4d76-a991-aa493ca00cbb.png)

With this the pipelines are also tested against Jenkins 2.378.1

Fixes #69 